### PR TITLE
Update PyQt6 to v6.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 VapourSynth>=65
 vstools>=3.0.0
 vsengine>=0.2.0
-PyQt6>=6.4.0
+PyQt6>=6.6.1
 PyQt6-sip>=13.4.0
 QDarkStyle>=3.1
 PyYAML>=6.0


### PR DESCRIPTION
Fixes tooltip styling.

Before:

![a](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/assets/140186177/9d9083d3-2457-4acf-b626-4e738f5b063e)

After:

![b](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/assets/140186177/4cf7817b-6c41-4029-ae32-bac4d2577466)
