### PR TITLE
Makes text in UI boxes readable again on windows when pyQt6 =<7.0. De…

### DIFF
--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -274,6 +274,7 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
 
             self.app.setStyleSheet(stylesheet)
 
+        if sys.platform == 'win32': self.app.setStyle("windowsvista")
         self.ensurePolished()
         self.reload_stylesheet_signal.emit()
         self.repaint()

--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -274,7 +274,9 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
 
             self.app.setStyleSheet(stylesheet)
 
-        if sys.platform == 'win32': self.app.setStyle("windowsvista")
+        if sys.platform == 'win32':
+            self.app.setStyle("windowsvista")
+
         self.ensurePolished()
         self.reload_stylesheet_signal.emit()
         self.repaint()


### PR DESCRIPTION
…fault Windows Qt style (windows11, windows10) causes issues.