### PR TITLE
Fix frames props view not updating on frame change

### DIFF
--- a/vspreview/plugins/builtins/frame_props.ppy
+++ b/vspreview/plugins/builtins/frame_props.ppy
@@ -106,3 +106,4 @@ class FramePropsPlugin(AbstractPlugin, QTableView):
             self._model._data.append(['Pixel aspect ratio', f"{props['_SARNum']}/{props['_SARDen']}"])
 
         self.setModel(self._model)
+        self._model.layoutChanged.emit()


### PR DESCRIPTION
2818451 updated the plugin to use a single `TableModel` instance, but changes to the underlying data are not emitted as signals, so the view doesn't update when the data changes. This patch fixes the issue by emitting the `layoutChanged` signal to trigger a redisplay.

Didn't use `dataChanged` because it's possible that there are more or less rows (props) in the new table data, hence a layout change. Also didn't implement this in `TableModel` since the data mutation is happening directly in the plugin.