### PR TITLE
Allow arbitrary number of digits in OGM chapter times

### DIFF
--- a/vspreview/toolbars/scening/toolbar.py
+++ b/vspreview/toolbars/scening/toolbar.py
@@ -583,11 +583,11 @@ class SceningToolbar(AbstractToolbar):
 
     def import_ogm_chapters(self, path: Path, scening_list: SceningList, out_of_range_count: int) -> None:
         '''
-        Imports chapters as signle-frame scenes.
+        Imports chapters as single-frame scenes.
         Uses NAME for scene label.
         '''
         pattern = re.compile(
-            r'(CHAPTER\d+)=(\d{2}):(\d{2}):(\d{2}(?:\.\d{3})?)\n\1NAME=(.*)',
+            r'(CHAPTER\d+)=(\d+):(\d+):(\d+(?:\.\d+)?)\n\1NAME=(.*)',
             re.RegexFlag.MULTILINE
         )
         for match in pattern.finditer(path.read_text('utf8')):


### PR DESCRIPTION
OGM chapters don't need to have strictly two digits for hours/minutes/seconds. Currently, copying vs-preview's own timestamps into the chapter file will result in them being skipped.

This matches MKVToolNix's behavior:
https://gitlab.com/mbunkus/mkvtoolnix/-/blob/18bd87e/src/common/chapters/chapters.cpp#L59

Also, fixed a typo in the docstring.