### PR TITLE
Fix Crashing issues

### DIFF
--- a/vspreview/plugins/builtins/slowpics_comp/main.py
+++ b/vspreview/plugins/builtins/slowpics_comp/main.py
@@ -512,6 +512,7 @@ class CompUploadWidget(ExtendedWidget):
             self.stop_upload_button.setVisible(False)
             self.upload_progressbar.setValue(int())
             self.upload_status_label.setText('Stopped!')
+            return
         else:
             self.upload_status_label.setText('Finished!')
 

--- a/vspreview/plugins/builtins/slowpics_comp/workers.py
+++ b/vspreview/plugins/builtins/slowpics_comp/workers.py
@@ -92,6 +92,9 @@ class Worker(QObject):
                 path_name = conf.path / folder_name
                 path_name.mkdir(parents=True)
 
+                if not conf.frames[i]:
+                    raise StopIteration("Output missing a frame.")
+
                 curr_filename = (path_name / folder_name).append_to_stem(f'%0{ndigits(max(conf.frames[i]))}d').with_suffix('.png')
 
                 clip = output.prepare_vs_output(


### PR DESCRIPTION
- Prevents crash if no frames were extracted.
- Don't start upload if it was stopped.