### PR TITLE
Fix PictType issue

### DIFF
--- a/vspreview/plugins/builtins/slowpics_comp/workers.py
+++ b/vspreview/plugins/builtins/slowpics_comp/workers.py
@@ -312,7 +312,7 @@ class FindFramesWorker(QObject):
                 _rnum_checked.add(rnum)
 
                 if all(
-                    cast(bytes, f.props['_PictType']) in picture_types_b
+                    get_prop(f.props, '_PictType', str, None, '').encode() in picture_types_b
                     for f in vs.core.std.Splice(
                         [out.prepared.clip[rnum] for out in conf.outputs], True
                     ).frames(close=True)


### PR DESCRIPTION
On ffms2 this match fails, I assume due to different encoding types. So we force it to be the same to fix it.