### PR TITLE
Rewrite slow.pics session handling

### DIFF
--- a/vspreview/plugins/builtins/slowpics_comp/main.py
+++ b/vspreview/plugins/builtins/slowpics_comp/main.py
@@ -664,7 +664,7 @@ class CompUploadWidget(ExtendedWidget):
             self.is_public_checkbox.isChecked(), self.is_nsfw_checkbox.isChecked(),
             True, delete_after, sample_frames_int, self.settings.compression, path,
             self.main, self.settings.delete_cache_enabled, self.settings.frame_type_enabled,
-            self.settings.browser_id, self.settings.session_id, tmdb_id, tags
+            self.settings.cookies_path, tmdb_id, tags
         )
 
     def find_samples(self, uuid: str) -> bool:


### PR DESCRIPTION
You no longer need to get cookies from your browser. I will now create its own session by using the user provided credentials. It only stores the cookies, so no password or usernames are stored on disk.