### PR TITLE
Update outputs combobox

### DIFF
--- a/vspreview/core/types/audio.py
+++ b/vspreview/core/types/audio.py
@@ -36,6 +36,7 @@ class AudioOutput(AbstractYAMLObject):
         with self.main.env:
             vs_outputs = list(x for x in vs.get_outputs().values() if isinstance(x, vs.AudioNode))
 
+        self.vs_index = index
         self.index = vs_outputs.index(vs_output)
         self.source_vs_output = vs_output
         self.vs_output = self.source_vs_output

--- a/vspreview/models/outputs.py
+++ b/vspreview/models/outputs.py
@@ -99,9 +99,11 @@ class Outputs(Generic[T], QAbstractListModel, QYAMLObject):
             return None
 
         if role == Qt.ItemDataRole.DisplayRole:
-            return self.items[index.row()].name
+            output = self.items[index.row()]
+            return f"{output.vs_index}: {output.name}"
         if role == Qt.ItemDataRole.EditRole:
-            return self.items[index.row()].name
+            output = self.items[index.row()]
+            return f"{output.vs_index}: {output.name}"
         if role == Qt.ItemDataRole.UserRole:
             return self.items[index.row()]
         return None

--- a/vspreview/toolbars/main/toolbar.py
+++ b/vspreview/toolbars/main/toolbar.py
@@ -56,9 +56,10 @@ class MainToolbar(AbstractToolbar):
             duplicatesEnabled=True, sizeAdjustPolicy=QComboBox.SizeAdjustPolicy.AdjustToContents
         )
         self.outputs_combobox.currentIndexChanged.connect(self.main.switch_output)
-        self.outputs_combobox.view().setMinimumWidth(
+        self.outputs_combobox.view().setMinimumWidth(  # type: ignore[union-attr]
             self.outputs_combobox.minimumSizeHint().width()
         )
+        self.outputs_combobox.lineEdit().setReadOnly(True)  # type: ignore[union-attr]
 
         self.frame_control = FrameEdit(self, valueChanged=self.main.switch_frame)
         if not self.settings.INSTANT_FRAME_UPDATE:

--- a/vspreview/toolbars/playback/toolbar.py
+++ b/vspreview/toolbars/playback/toolbar.py
@@ -153,6 +153,7 @@ class PlaybackToolbar(AbstractToolbar):
             self, editable=True, insertPolicy=QComboBox.InsertPolicy.InsertAtCurrent,
             duplicatesEnabled=True, sizeAdjustPolicy=QComboBox.SizeAdjustPolicy.AdjustToContents
         )
+        self.audio_outputs_combobox.lineEdit().setReadOnly(True)  # type: ignore[union-attr]
 
         self.audio_volume_slider = QSlider(Qt.Orientation.Horizontal, valueChanged=self.setVolume)  # type: ignore
         self.audio_volume_slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)


### PR DESCRIPTION
This PR makes the line edit of the ouputs combo boxes as read only to prevent the user to write in it while still allowing them to select the text.
Additionally, the line edit is now displaying the index number of the outputs.