### PR TITLE
Make transfer characteristics identical if input is RGB

### DIFF
--- a/vspreview/core/types/video.py
+++ b/vspreview/core/types/video.py
@@ -321,6 +321,7 @@ class VideoOutput(AbstractYAMLObject):
         })
 
         if src.format.color_family == vs.RGB:
+            resizer_kwargs['transfer'] = resizer_kwargs['transfer_in']
             del resizer_kwargs['matrix_in']
         elif src.format.color_family == vs.GRAY:
             clip = clip.std.RemoveFrameProps('_Matrix')


### PR DESCRIPTION
Currently, (output) transfer characteristics are always assumed to be BT.709 if standard-gamut video is provided, this will result in washed out colors if our input is RGB.

Reference/Expected output
![00415](https://github.com/user-attachments/assets/8c82b3f3-8bbf-4420-b454-aa03693814af)

Current output
![current](https://github.com/user-attachments/assets/5a31cde0-9700-455c-8ae4-c27767284938)

This commit sets the output transfer characteristics to the input ones if input is RGB.