### PR TITLE
Write more user-friendly dependency error

### DIFF
--- a/vspreview/core/vsenv.py
+++ b/vspreview/core/vsenv.py
@@ -8,7 +8,7 @@ from threading import Lock
 from typing import Any, Callable, TypeVar
 
 from jetpytools import CustomImportError, DependencyNotFoundError
-from vstools import core
+from vstools import vs
 from PyQt6.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal
 from vapoursynth import CoreCreationFlags, LogHandle
 from vsengine.loops import EventLoop, set_loop  # type: ignore[import-untyped]
@@ -59,7 +59,13 @@ def _monkey_runpy_func(*args: Any, **kwargs: Any) -> Any:
 
     except AttributeError as e:
         # Only handle VapourSynth-related attribute errors
-        if not hasattr(e, 'obj') or not isinstance(e.obj, core):
+        vs_types = (
+            type(vs), vs.VideoNode, vs.VideoFrame, vs.RawNode,
+            vs.VideoFormat, vs.Core, vs.Plugin, vs.Function,
+            vs.AudioNode, vs.AudioFrame
+        )
+
+        if not hasattr(e, 'obj') or not any(isinstance(e.obj, t) for t in vs_types):
             raise
 
         dep = e.name if hasattr(e, 'name') else str(e).partition('named ')[2].partition('.')[0].strip()

--- a/vspreview/core/vsenv.py
+++ b/vspreview/core/vsenv.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future
 from threading import Lock
 from typing import Any, Callable, TypeVar
 
+from jetpytools import CustomImportError, DependencyNotFoundError
 from PyQt6.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal
 from vapoursynth import CoreCreationFlags, LogHandle
 from vsengine.loops import EventLoop, set_loop  # type: ignore[import-untyped]
@@ -41,7 +42,45 @@ class FlagsPolicy(Policy):
 
 
 def _monkey_runpy_func(*args: Any, **kwargs: Any) -> Any:
-    glob_dict = orig_runpy_run_code(*args, **kwargs)
+    # TODO: Update the guide to better separate plugins and Python packages, then update this URL
+    base_url = 'https://jaded-encoding-thaumaturgy.github.io/JET-guide/master'
+    guide_url = f'{base_url}/basics/installation/#installing-vapoursynth-plugins'
+
+    try:
+        glob_dict = orig_runpy_run_code(*args, **kwargs)
+    except (AttributeError, ModuleNotFoundError) as e:
+        is_attr = isinstance(e, AttributeError)
+
+        if is_attr:
+            dep = str(e).partition('named ')[2].partition('.')[0].strip()
+        else:
+            dep = str(e).partition('\'')[2].rstrip('\'').strip()
+
+        raise DependencyNotFoundError(
+            'vspreview', dep,
+            f'Could not find the {("plugin" if is_attr else "Python package")}, \'{dep}\'! '
+            f'Please install it and try again.\n'
+            f'See {guide_url} for installation instructions.'
+        )
+
+    except ImportError as e:
+        err_msg = str(e)
+        parts = err_msg.split('\'')
+
+        if len(parts) > 3:
+            dep, pkg = parts[1], parts[3]
+        else:
+            dep, pkg = parts[1], ''
+
+        pkg_path = err_msg[err_msg.rfind('(') + 1:err_msg.rfind(')')].strip()
+
+        raise CustomImportError(
+            pkg, dep,
+            f'Failed to import \'{dep}\' from the installed package @ \'{pkg_path}\'! '
+            f'Please check that the package is installed correctly and up to date.\n'
+            f'See {guide_url} for installation instructions.'
+        )
+
 
     if '_monkey_runpy' in glob_dict:
         _monkey_runpy_dicts[glob_dict['_monkey_runpy']] = glob_dict


### PR DESCRIPTION
This should help users better understand the dependency errors, as well as link to a resource that's easier to update without having to change the exception message.