### PR TITLE
Add doc on how to start vs-preview asynchronously in vim/neovim

### DIFF
--- a/docs/installation/install_vim.rst
+++ b/docs/installation/install_vim.rst
@@ -51,3 +51,33 @@ If there's an error with your script,
 it will print it in the terminal.
 If your script is fine,
 it will open ``vs-preview`` with the current script.
+
+
+.. note::
+
+    In the simple configuration above, vs-preview will not run asynchronously, meaning that vim/neovim will be frozen until vs-preview is quit. In Vim 8 (or later) and Neovim, it's possible to start vs-preview asynchronously by having the following lines in your ``_vimrc`` file.
+
+.. code-block:: vimscript
+    :linenos:
+
+    nnoremap r :w<enter>:call AsynchronousVsPreview(expand("%:p"))<enter>
+
+    function! AsynchronousVsPreview(file_path)
+        let l:vsPreview_cmd = 'vspreview '.a:file_path 
+        if exists('g:job_vs')
+            if has('nvim')
+                call jobstop(g:job_vs)
+            else
+                call job_stop(g:job_vs)
+            endif
+            unlet g:job_vs
+            echom 'Stopping vs-preview...'
+        else
+            if has('nvim')
+                let g:job_vs = jobstart(l:vsPreview_cmd, {})
+            else
+                let g:job_vs = job_start(l:vsPreview_cmd, {})
+            endif
+            echom 'Starting vs-preview asynchronously...'
+        endif
+    endfunction


### PR DESCRIPTION
In the previously suggested installation with vim/neovim, you had the editor frozen until vs-preview was quit, with no possibility of modifying the script in the editor and reloading it vs-preview. This PR adds information on how to use the jobcontrol feature in vim/neovim to start vs-preview asynchronously.