### PR TITLE
Remove clear_monkey_runpy when script is loading successfully

### DIFF
--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -750,8 +750,10 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
 
         try:
             self.load_script(self.script_path, self.external_args, True, None, self.display_name)
-        finally:
+        except BaseException:
             self.clear_monkey_runpy()
+        finally:
+            pass
 
         self.reload_after_signal.emit()
 


### PR DESCRIPTION
Removing the second call to `clear_monkey_runpy` appears to fix #232. I'm not entirely sure what the side effects might be. I left the `try/except` statements in place in case `load_script` can throw an error (if that's even possible).
