### PR TITLE
dont make setup_shortcuts dependent on reloading

### DIFF
--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -424,8 +424,7 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
         except Exception as e:
             load_error = e
 
-        if not reloading:
-            self.shortcuts.setup_shortcuts()
+        self.shortcuts.setup_shortcuts()
         self.apply_stylesheet()
         self.timeline.set_sizes()
 

--- a/vspreview/shortcuts/settings.py
+++ b/vspreview/shortcuts/settings.py
@@ -27,6 +27,7 @@ class ShortCutsSettings(AbstractSettingsScrollArea):
     main: MainWindow
     sections: dict[str, AbtractShortcutSection]
     sections_plugins: dict[str, "PluginSection"]
+    shortcuts_setup_already: bool
 
     def __init__(self, main_window: MainWindow) -> None:
         self.main = main_window
@@ -41,6 +42,7 @@ class ShortCutsSettings(AbstractSettingsScrollArea):
             "script_error": ScriptErrorDialogSection(self),
         }
         self.sections_plugins = {ns: PluginSection(self, plugin) for ns, plugin in self.main.plugins.plugins.items()}
+        self.shortcuts_setup_already = False
         super().__init__()
 
     def setup_ui(self) -> None:
@@ -82,8 +84,10 @@ class ShortCutsSettings(AbstractSettingsScrollArea):
         pass
 
     def setup_shortcuts(self) -> None:
-        for section in self.sections.values():
-            section.setup_shortcuts()
+        if not self.shortcuts_setup_already:
+            for section in self.sections.values():
+                section.setup_shortcuts()
+            self.shortcuts_setup_already = True
 
     def __getstate__(self) -> dict[str, Any]:
         state = super().__getstate__()


### PR DESCRIPTION
Issue: When a script errors on first load, shortcuts don't work.

This is probably because load_script has early exit on error before setup_shortcuts is called and it isn't called subsequently because reloading is True .
This pr unconditionally calls setup_shortcuts but only does sth. once.

repro:
```
from vstools import *
#core.std.BlankClip().set_output(0)
```
`vspreview a.py`
change to 
```
from vstools import *
core.std.BlankClip().set_output(0)
```
Hit Reload Button

script loads but Ctrl+R doesn't work