### PR TITLE
fix error when passing arguments to script

### DIFF
--- a/vspreview/init.py
+++ b/vspreview/init.py
@@ -198,7 +198,7 @@ def main(_args: Sequence[str] | None = None, no_exit: bool = False) -> int:
         return k.strip("--"), v
 
     if args.plugins:
-        if file_resolve_plugin._config.namespace == "dev.setsugen.vssource_load":
+        if file_resolve_plugin and file_resolve_plugin._config.namespace == "dev.setsugen.vssource_load":
             additional_files = list[Path](
                 Path(filepath).resolve() for filepath in args.plugins
             )


### PR DESCRIPTION

repro:
```python
from vstools import *

print(ASD)
core.std.BlankClip().set_output(0)
```
```python
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/user/git/vs-preview-git/vspreview/__main__.py", line 5, in <module>
    main()
    ~~~~^^
  File "vs-preview-git/vspreview/init.py", line 201, in main
    if file_resolve_plugin._config.namespace == "dev.setsugen.vssource_load":
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_config'
```
```bash
python -m vspreview test.py ASD=test
```
probably introduced by https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/commit/fa70ddfb6533ce9f86d75e4eb3aecd16cfdaab4d

file_resolve_plugin is None if file is not handled by a plugin