### PR TITLE
try fix #231

### DIFF
--- a/vspreview/main/timeline.py
+++ b/vspreview/main/timeline.py
@@ -103,6 +103,8 @@ class Timeline(QWidget):
         self.drawWidget(QPainter(self))
 
     def drawWidget(self, painter: QPainter) -> None:
+        if not self.main.current_output:
+            return
         setup_key = (self.rect_f, self.main.current_output.index)
 
         curr_key, (scroll_rect, labels_notches, rects_to_draw) = self.notches_cache[self.mode]

--- a/vspreview/main/window.py
+++ b/vspreview/main/window.py
@@ -462,9 +462,6 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
         if not isinstance(e, vpy.ExecutionFailed):
             e = vpy.ExecutionFailed(e)
 
-        self.hide()
-        self.apply_stylesheet()
-
         te = TracebackException.from_exception(e.parent_error)
         logging.error(''.join(te.format()))
 
@@ -872,6 +869,9 @@ class MainWindow(AbstractQItem, QMainWindow, QAbstractYAMLObjectSingleton):
             view.setZoom(bound_view.zoom_combobox.currentData())
 
     def handle_script_error(self, message: str, script: bool = False) -> None:
+        self.hide()
+        self.apply_stylesheet()
+
         self.clear_monkey_runpy()
         self.script_error_dialog.label.setText(message)
         self.script_error_dialog.setWindowTitle('Script Loading Error' if script else 'Program Error')


### PR DESCRIPTION
The crash/abort is tangentially related to the actual error and seems to occur consistently [here](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/blob/211400245a9403bd38fe6657d56b5a5970a035c0/vspreview/models/outputs.py#L93). Just not drawing the widget seems to be fine in case of script error.

This PR also fixes a the "same?" crash for when the reloading script doesn't have any outputs. The hiding of the window which was previously done only for when a script erred on load is done on no outputs now aswell, by moving that into handle_script_error. 

Feel free to just not merge this since to me this seems like just a workaround, but the crash is really annoying  and seems fixed.